### PR TITLE
Removal of images were failing since the original logic didn't look a…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM       debian:jessie
 MAINTAINER Johannes 'fish' Ziemke <fish@docker.com> (@discordianfish)
 
 RUN        apt-get update && apt-get install -yq curl git
-RUN        curl -s https://go.googlecode.com/files/go1.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN        curl -s https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV        PATH    /usr/local/go/bin:$PATH
 ENV        GOPATH  /go
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 This tool will delete all containers that are:
 
 - not running
-- exited before `-ca` hours ago
+- exit time is older than `-ca` hours ago
 - not used as volume containers by containers created after `-ca` hours ago
 
 And will attempt(!) to delete *all* images that are:
 
-- created before `-ia` hours ago
+- creation time is older than `-ia` hours ago
 - not used by any container created after `-ca` hours ago
 
 If unsure, use `-dry` before running it.


### PR DESCRIPTION
…t intermediate images (parents)
- Update help in regards to -ca and -ia
- Switch to use go 1.4.2
- Update to use latest dockerclient. https://github.com/samalba/dockerclient/pull/130
  adds support to ListImages to list all images
- Don't exit if can't inspect or get container exit time; continue instead
